### PR TITLE
Use `next.config.mjs` in Next example

### DIFF
--- a/sandbox-templates/mdx-loader-next/next.config.mjs
+++ b/sandbox-templates/mdx-loader-next/next.config.mjs
@@ -1,7 +1,7 @@
 // ⚠️ Important! Please make sure the dependencies are up to date.
 // You can refresh them in the Dependencies section (left-bottom on CodeSandbox)
 
-module.exports = {
+const configuration = {
   // Support MDX files as pages:
   pageExtensions: ["md", "mdx", "tsx", "ts", "jsx", "js"],
   // Support loading `.md`, `.mdx`:
@@ -24,3 +24,5 @@ module.exports = {
     return config;
   },
 };
+
+export default configuration;


### PR DESCRIPTION
this makes it easier to load ESM packages like remark and rehype plugins

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
