### PR TITLE
Add CodeSandbox, StackBlitz links to bug form

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -40,10 +40,13 @@ body:
       description: |
         Link to repository or sandbox with runnable example of the issue.
 
-        Some CodeSandbox starters:
-        - [MDX Loader with Next.js](https://codesandbox.io/s/github/mdx-js/.github/tree/main/sandbox-templates/mdx-loader-next)
-        - [MDX Evaluate with Node.js](https://codesandbox.io/s/github/mdx-js/.github/tree/main/sandbox-templates/mdx-evaulate-node)
-        - [MDX Evaluate with Create React App](https://codesandbox.io/s/github/mdx-js/.github/tree/main/sandbox-templates/mdx-evaluate-create-react-app)
+        Some starters:
+
+        | description | codesandbox | stackblitz |
+        | - | - | - |
+        | MDX Loader with Next.js | [codesandbox](https://codesandbox.io/s/github/mdx-js/.github/tree/main/sandbox-templates/mdx-loader-next) | [stackblitz](https://stackblitz.com/github/mdx-js/.github/tree/main/sandbox-templates/mdx-loader-next) | 
+        | MDX Evaluate with Node.js | [codesandbox](https://codesandbox.io/s/github/mdx-js/.github/tree/main/sandbox-templates/mdx-evaulate-node) | [stackblitz](https://stackblitz.com/github/mdx-js/.github/tree/main/sandbox-templates/mdx-evaulate-node) |
+        | MDX Evaluate with Create React App | [codesandbox](https://codesandbox.io/s/github/mdx-js/.github/tree/main/sandbox-templates/mdx-evaluate-create-react-app) | [stackblitz](https://stackblitz.com/github/mdx-js/.github/tree/main/sandbox-templates/mdx-evaluate-create-react-app) |
 
         Alternatively, use the next section *Steps to reproduce*.
     validations:

--- a/sandbox-templates/mdx-evaluate-create-react-app/.stackblitzrc
+++ b/sandbox-templates/mdx-evaluate-create-react-app/.stackblitzrc
@@ -1,0 +1,3 @@
+{
+  "startCommand": "npm start"
+}

--- a/sandbox-templates/mdx-evaluate-create-react-app/package.json
+++ b/sandbox-templates/mdx-evaluate-create-react-app/package.json
@@ -7,11 +7,11 @@
     "@mdx-js/mdx": "2.0.0-rc.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-scripts": "5.0.0-next.58"
+    "react-scripts": "5.0.0"
   },
   "devDependencies": {
-    "@babel/runtime": "7.16.3",
-    "typescript": "4.5.2"
+    "@babel/runtime": "7.16.7",
+    "typescript": "4.4.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/sandbox-templates/mdx-evaluate-create-react-app/sandbox.config.json
+++ b/sandbox-templates/mdx-evaluate-create-react-app/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "startScript": "start"
+}

--- a/sandbox-templates/mdx-evaulate-node/.stackblitzrc
+++ b/sandbox-templates/mdx-evaulate-node/.stackblitzrc
@@ -1,0 +1,3 @@
+{
+  "startCommand": "npm start"
+}

--- a/sandbox-templates/mdx-evaulate-node/sandbox.config.json
+++ b/sandbox-templates/mdx-evaulate-node/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "startScript": "start"
+}

--- a/sandbox-templates/mdx-loader-next/.stackblitzrc
+++ b/sandbox-templates/mdx-loader-next/.stackblitzrc
@@ -1,0 +1,3 @@
+{
+  "startCommand": "npm start"
+}

--- a/sandbox-templates/mdx-loader-next/sandbox.config.json
+++ b/sandbox-templates/mdx-loader-next/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "startScript": "start"
+}


### PR DESCRIPTION
* issue for now links to both codesandbox and stackblitz starters
* starters now include codesandbox and stackblitz configuration files
* create react app starter now has updated dependencies

<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->
