### PR TITLE
Fix typo

### DIFF
--- a/profile/readme.md
+++ b/profile/readme.md
@@ -8,7 +8,7 @@
 
 #### unified
 
-MDX is part of the unified collective ([`unifiedjs.com`][site]), which brings
+MDX is part of the unified collective ([`unifiedjs.com`][unified]), which brings
 together organisations that work with content as structured data.
 
 #### Get involved
@@ -23,6 +23,8 @@ together organisations that work with content as structured data.
 [logo]: https://raw.githubusercontent.com/mdx-js/.github/5a63e56/image/cover.svg?sanitize=true
 
 [site]: https://mdxjs.com
+
+[unified]: https://unifiedjs.com
 
 [twitter]: https://twitter.com/mdx_js
 


### PR DESCRIPTION
Just noticed the link for unifiedjs.com in the org profile readme is pointing to https://mdxjs.com, so thought I'd submit a fix! 👋 