### PR TITLE
Update dependencies in sandboxes

### DIFF
--- a/sandbox-templates/mdx-evaluate-create-react-app/package.json
+++ b/sandbox-templates/mdx-evaluate-create-react-app/package.json
@@ -4,14 +4,14 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@mdx-js/mdx": "2.1.1",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "react-scripts": "5.0.0"
+    "@mdx-js/mdx": "^2.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-scripts": "^5.0.0"
   },
   "devDependencies": {
-    "@babel/runtime": "7.16.7",
-    "typescript": "4.6.3"
+    "@babel/runtime": "^7.0.0",
+    "typescript": "~4.9.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/sandbox-templates/mdx-evaulate-node/index.js
+++ b/sandbox-templates/mdx-evaulate-node/index.js
@@ -2,8 +2,8 @@
 // You can refresh them in the Dependencies section (left-bottom on CodeSandbox)
 
 import http from "node:http";
-import * as runtime from "react/jsx-runtime.js";
-import ReactDom from "react-dom/server.js";
+import * as runtime from "react/jsx-runtime";
+import ReactDom from "react-dom/server";
 import { evaluate } from "@mdx-js/mdx";
 
 // Note: refresh the pane on the right to see changes.

--- a/sandbox-templates/mdx-evaulate-node/package.json
+++ b/sandbox-templates/mdx-evaulate-node/package.json
@@ -8,9 +8,9 @@
     "start": "nodemon index.js"
   },
   "dependencies": {
-    "@mdx-js/mdx": "2.1.1",
-    "nodemon": "2.0.15",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "@mdx-js/mdx": "^2.0.0",
+    "nodemon": "^2.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/sandbox-templates/mdx-loader-next/package.json
+++ b/sandbox-templates/mdx-loader-next/package.json
@@ -9,9 +9,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@mdx-js/loader": "2.1.1",
-    "next": "12.1.4",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "@mdx-js/loader": "^2.0.0",
+    "next": "^13.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

TypeScript is unpinned since https://github.com/mdx-js/.github/pull/30#discussion_r780791604 is now resolved.
React is upgraded to next major, next.js is also upgraded to next major.


Current demo links (these stop working after merge):
https://codesandbox.io/s/github/ChristianMurphy/.github-mdx/tree/update-sandbox-package-deps/sandbox-templates/mdx-loader-next
https://codesandbox.io/s/github/ChristianMurphy/.github-mdx/tree/update-sandbox-package-deps/sandbox-templates/mdx-evaluate-create-react-app
https://codesandbox.io/s/github/ChristianMurphy/.github-mdx/tree/update-sandbox-package-deps/sandbox-templates/mdx-evaulate-node

resolves https://github.com/mdx-js/.github/pull/46
resolves https://github.com/mdx-js/.github/pull/45
resolves https://github.com/mdx-js/.github/pull/44
resolves https://github.com/mdx-js/.github/pull/43
resolves https://github.com/mdx-js/.github/pull/42
resolves https://github.com/mdx-js/.github/pull/35